### PR TITLE
Documentation typos for HASS

### DIFF
--- a/docs/modules/EMS_HASS.md
+++ b/docs/modules/EMS_HASS.md
@@ -29,13 +29,13 @@ The following table shows the available configuration parameters for the HASS EM
 ### JSON Configuration Example
 
 ```
-"Fronius": {
+"HASS": {
   "apiKey": "ABC123",
   "enabled": true,
   "hassEntityConsumption": "sensor.consumption",
   "hassEntityGeneration": "sensor.generation",
   "serverIP": "192.168.1.2",
-  "serverPort": 80
+  "serverPort": 8123
 }
 ```
 


### PR DESCRIPTION
As this number is also used for status reporting and initially was an int - I think it's best to limit this to 2 digits.  